### PR TITLE
feat(action): allow githup app private key to be specified via action…

### DIFF
--- a/src/OpenWhiskWrapper.js
+++ b/src/OpenWhiskWrapper.js
@@ -106,9 +106,6 @@ module.exports = class OpenWhiskWrapper {
   }
 
   async initProbot(params) {
-    if (!this._privateKey) {
-      this._privateKey = findPrivateKey();
-    }
     const options = {
       id: this._appId,
       secret: this._secret,
@@ -150,12 +147,15 @@ module.exports = class OpenWhiskWrapper {
         __ow_body: body,
       } = params;
 
-      // set APP_ID and WEBHOOK_SECRET if defined via params
+      // set APP_ID, WEBHOOK_SECRET and PRIVATE_KEY if defined via params
       if (!this._appId) {
-        this._appId = params.GH_APP_ID || process.env.APP_ID;
+        this._appId = params.GH_APP_ID;
       }
       if (!this._secret) {
-        this._secret = params.GH_WEBHOOK_SECRET || process.env.WEBHOOK_SECRET;
+        this._secret = params.GH_APP_WEBHOOK_SECRET;
+      }
+      if (!this._privateKey) {
+        this._privateKey = params.GH_APP_PRIVATE_KEY || findPrivateKey();
       }
 
       // check if the event is triggered via params.
@@ -231,7 +231,7 @@ module.exports = class OpenWhiskWrapper {
       logWrapper.init(logger, params);
 
       // eslint-disable-next-line no-underscore-dangle
-      logger.debug('Params: "%s" "%s"\n', params.__ow_method, params.__ow_path || '/', params.__ow_headers);
+      logger.debug('>> %s %s"\n', (params.__ow_method || 'get').toUpperCase(), params.__ow_path || '/', params.__ow_headers);
 
       // run actual action
       const result = await run(params);

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -267,34 +267,20 @@ describe('OpenWhisk Wrapper - Handler', () => {
     });
   });
 
-  it('it can set APP_ID and WEBHOOK_SECRET from params', async () => {
+  it('it can set APP_ID, WEBHOOK_SECRET, and PRIVATE_KEY from params', async () => {
+    const privateKey = await fs.readFile(PRIVATE_KEY_PATH);
     const wrapper = new OpenWhiskWrapper()
-      .withGithubPrivateKey(await fs.readFile(PRIVATE_KEY_PATH))
-      .withWebhookSecret(WEBHOOK_SECRET)
       .withApp('./test/fixtures/issues-opened-handler.js');
 
     const payload = await createTestPayload({});
     payload.GH_APP_ID = '1234';
-    payload.GH_WEBHOOK_SECRET = 'test';
+    payload.GH_APP_WEBHOOK_SECRET = 'test';
+    payload.GH_APP_PRIVATE_KEY = privateKey;
     await wrapper.create()(payload);
 
-    assert.ok(wrapper._appId, '1234');
-    assert.ok(wrapper._secret, 'test');
-  });
-
-  it('it can set APP_ID and WEBHOOK_SECRET from process.env', async () => {
-    const wrapper = new OpenWhiskWrapper()
-      .withGithubPrivateKey(await fs.readFile(PRIVATE_KEY_PATH))
-      .withWebhookSecret(WEBHOOK_SECRET)
-      .withApp('./test/fixtures/issues-opened-handler.js');
-
-    const payload = await createTestPayload({});
-    process.env.APP_ID = '1234';
-    process.env.WEBHOOK_SECRET = 'test';
-    await wrapper.create()(payload);
-
-    assert.ok(wrapper._appId, '1234');
-    assert.ok(wrapper._secret, 'test');
+    assert.equal(wrapper._appId, '1234');
+    assert.equal(wrapper._secret, 'test');
+    assert.equal(wrapper._privateKey, privateKey);
   });
 
   it('it can set APP_ID and WEBHOOK_SECRET via setters', async () => {
@@ -307,8 +293,8 @@ describe('OpenWhisk Wrapper - Handler', () => {
     const payload = await createTestPayload({});
     await wrapper.create()(payload);
 
-    assert.ok(wrapper._appId, '1234');
-    assert.ok(wrapper._secret, WEBHOOK_SECRET);
+    assert.equal(wrapper._appId, '1234');
+    assert.equal(wrapper._secret, WEBHOOK_SECRET);
   });
 
   it('error during init probot sends 500', async () => {


### PR DESCRIPTION
… params

fixes #64

BREAKING CHANGE: The GH_WEBHOOK_SECRET param in now called GH_APP_WEBHOOK_SECRET.
BREAKING CHANGE: the secret and appId can no longer be loaded from env.APP_ID and env.WEBHOOK_SECRET